### PR TITLE
Missing stream handlers for chainability

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var gulp = require('gulp'),
     rjs = require('gulp-requirejs');
 
 gulp.task('requirejsBuild', function() {
-    rjs({
+    return rjs({
         baseUrl: 'path/to/your/base/file.js',
         out: 'FILENAME\_TO\_BE\_OUTPUTTED',
         shim: {
@@ -54,6 +54,8 @@ gulp.task('requirejsBuild', function() {
         .pipe(gulp.dest('./delpoy/')); // pipe it to the output DIR
 });
 ```
+
+Note: In order to let gulp know that the optimization completes, return the rjs stream.
 
 ### Error handling
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ module.exports = function(opts) {
                 path: _fName,
                 contents: new Buffer(text)
             }));
+            _s.resume();
+            _s.end();
         });
     // } catch (err) {
     //     _s.emit('error', err);


### PR DESCRIPTION
These changes were done to make Gulp know when optimization was finished so other subsequent tasks can be chained.

Changing documentation too so that everybody know how it should be used.

