### PR TITLE
Don't try to create file with no output

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,11 @@ module.exports = function(opts) {
   }
 
   var success = function(buildResponse) {
-    stream.write(createFile(filename, output, buildResponse, sourceMapOutput));
+    if (output) {
+      stream.write(
+        createFile(filename, output, buildResponse, sourceMapOutput)
+      );
+    }
     stream.resume();
     stream.end();
   };


### PR DESCRIPTION
If using the optimizer to only build modules and/or with the `dir` option, `output` is never set and the `Buffer.from(output)` in `createFile()` fails. So let's not do that.